### PR TITLE
Revert "Fix for EXIT_MEMORY_FAULT"

### DIFF
--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1575,14 +1575,6 @@ impl VcpuFd {
                     Ok(VcpuExit::IoapicEoi(eoi.vector))
                 }
                 KVM_EXIT_HYPERV => Ok(VcpuExit::Hyperv),
-                KVM_EXIT_MEMORY_FAULT => {
-                    let fault = unsafe { &mut run.__bindgen_anon_1.memory_fault };
-                    Ok(VcpuExit::MemoryFault {
-                        flags: fault.flags,
-                        gpa: fault.gpa,
-                        size: fault.size,
-                    })
-                }
                 r => Ok(VcpuExit::Unsupported(r)),
             }
         } else {


### PR DESCRIPTION
This reverts commit 08a7c089560a9a38c58b26aedb5316be3efbb8bb since the issue has been already fixed upstream (cca host series).