### PR TITLE
Add KVM_CAP_GUEST_MEMFD

### DIFF
--- a/src/cap.rs
+++ b/src/cap.rs
@@ -172,4 +172,5 @@ pub enum Cap {
     ExitHypercall = KVM_CAP_EXIT_HYPERCALL,
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     MemoryFaultInfo = KVM_CAP_MEMORY_FAULT_INFO,
+    GuestMemfd = KVM_CAP_GUEST_MEMFD,
 }


### PR DESCRIPTION
Just adds the required to compile latest arm cca support on libkrun. In the future, we wont rely on this repo so I did not rebase on latest kvm-ioctl.